### PR TITLE
Update friendly_sql.md

### DIFF
--- a/docs/sql/dialect/friendly_sql.md
+++ b/docs/sql/dialect/friendly_sql.md
@@ -36,7 +36,7 @@ DuckDB offers several advanced SQL features and syntactic sugar to make SQL quer
 
 ## Query Features
 
-* [Column aliases in `WHERE`, `GROUP BY`, and `HAVING`]({% post_url 2022-05-04-friendlier-sql %}#column-aliases-in-where--group-by--having)
+* [Column aliases in `WHERE`, `GROUP BY`, and `HAVING`]({% post_url 2022-05-04-friendlier-sql %}#column-aliases-in-where--group-by--having). But column aliases cannot be used in the `ON` clause of the [JOIN Clauses]({% link docs/sql/query_syntax/from.md %}#joins).
 * [`COLUMNS()` expression]({% link docs/sql/expressions/star.md %}#columns-expression) can be used to execute the same expression on multiple columns:
     * [with regular expressions]({% post_url 2023-08-23-even-friendlier-sql %}#columns-with-regular-expressions)
     * [with `EXCLUDE` and `REPLACE`]({% post_url 2023-08-23-even-friendlier-sql %}#columns-with-exclude-and-replace)


### PR DESCRIPTION
Just want to make it clear that the column alias cannot be used in the ON clause of the JOIN clauses. I didn't find any specific instructions in the documentation, so I'll add the description in this section.

Here are the test result:
```
duckdb> WITH T1 AS (
   ...> SELECT
   ...> 1 AS X,
   ...> 2 AS Y
   ...> ),
   ...> T2 AS (
   ...> SELECT
   ...> 1 AS X,
   ...> 4 AS Y
   ...> )
   ...> SELECT T1.X AS T1X, T2.X AS T2X
   ...> FROM T1 LEFT JOIN T2 ON T1.X = T2X;
Binder Error: Referenced column "T2X" not found in FROM clause!
Candidate bindings: "T2.X"
LINE 12: FROM T1 LEFT JOIN T2 ON T1.X = T2X;
                                        ^

duckdb> WITH T1 AS (
   ...> SELECT
   ...> 1 AS X,
   ...> 2 AS Y
   ...> ),
   ...> T2 AS (
   ...> SELECT
   ...> 1 AS X,
   ...> 4 AS Y
   ...> )
   ...> SELECT T1.X AS T1X, T2.X AS T2X
   ...> FROM T1, T2 
   ...> where T1.X = T2X;
┌─────┬─────┐
│ T1X ┆ T2X │
╞═════╪═════╡
│   1 ┆   1 │
└─────┴─────┘
```
